### PR TITLE
Map -DspotlessIdeHook through Eel for ijent Dev Containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+## 1.2.4
+
+- Support Dev Containers in `ijent` mode which is JetBrain's new
+  architecture for Dev Containers and became the default
+  with IntelliJ IDEA 2026.1.
+  - [#55](https://github.com/lipiridi/spotless-applier/pull/55)
+    Map -DspotlessIdeHook through Eel for ijent Dev Containers
+
 ## [1.2.3] - 2026-04-10
 
 - [#49](https://github.com/lipiridi/spotless-applier/issues/49) Maven - Fix path containing space in Linux

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginName=Spotless Applier
 pluginRepositoryUrl=https://github.com/lipiridi/spotless-applier
 
 # SemVer format -> https://semver.org
-pluginVersion=1.2.3
+pluginVersion=1.2.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=253

--- a/src/main/java/com/github/lipiridi/spotless/applier/ReformatProcessor.java
+++ b/src/main/java/com/github/lipiridi/spotless/applier/ReformatProcessor.java
@@ -21,8 +21,12 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Version;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.eel.provider.EelNioBridgeServiceKt;
+import com.intellij.platform.eel.provider.utils.EelPathUtils;
 import com.intellij.psi.PsiFile;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -141,8 +145,8 @@ public class ReformatProcessor {
         externalSettings.setTaskNames(Collections.singletonList("spotlessApply"));
         externalSettings.setExternalSystemIdString(GradleConstants.SYSTEM_ID.getId());
         if (reformatSpecificFile) {
-            scriptParameters = String.format(
-                    "-PspotlessIdeHook=\"%s\" %s", psiFile.getVirtualFile().getCanonicalPath(), scriptParameters);
+            scriptParameters =
+                    String.format("-PspotlessIdeHook=\"%s\" %s", resolveSpotlessIdeHookPath(), scriptParameters);
         }
 
         externalSettings.setScriptParameters(scriptParameters);
@@ -173,7 +177,7 @@ public class ReformatProcessor {
         List<String> commands = new ArrayList<>();
         commands.add("spotless:apply");
         if (reformatSpecificFile) {
-            final String rawPath = psiFile.getVirtualFile().getCanonicalPath();
+            final String rawPath = resolveSpotlessIdeHookPath();
             final String adjusted;
             final String rootPath = File.listRoots()[0].getPath();
             if (rootPath.equals("/")) { // Unix / Linux / macOS
@@ -235,5 +239,25 @@ public class ReformatProcessor {
 
     private String getModuleName() {
         return module == null ? project.getName() : module.getName();
+    }
+
+    /**
+     * Returns the absolute path of the file being reformatted, expressed in the filesystem of the
+     * build tool process. For local projects this is just the host path. For projects opened via
+     * Gateway's ijent-based Dev Container mode, {@link VirtualFile#toNioPath()} hands back a path
+     * inside the host-side Eel virtual filesystem (rendered as
+     * {@code //$devcontainer.ij/<hash>@/workspaces/...}), which is meaningless to the in-container
+     * {@code mvn}/{@code gradlew} child process. The Eel bridge translates it to the
+     * container-internal absolute path the child can resolve.
+     */
+    @SuppressWarnings("UnstableApiUsage")
+    private String resolveSpotlessIdeHookPath() {
+        VirtualFile virtualFile = psiFile.getVirtualFile();
+        Path nioPath = virtualFile.toNioPath();
+        if (EelPathUtils.isPathLocal(nioPath)) {
+            String canonical = virtualFile.getCanonicalPath();
+            return canonical != null ? canonical : nioPath.toString();
+        }
+        return EelNioBridgeServiceKt.asEelPath(nioPath).toString();
     }
 }


### PR DESCRIPTION
***Context:** Using Spotless-Applier plugin within an IntelliJ Dev-Container in "ijent" mode which is JetBrains' new architecture for Dev Containers, where the full IntelliJ runs on the host and only a thin daemon runs inside the container. It became the default workflow with IntelliJ IDEA 2026.1 (https://blog.jetbrains.com/idea/2026/03/intellij-idea-2026-1/); see Open a project with Dev Container natively (https://www.jetbrains.com/help/idea/open-project-with-dev-container-natively.html) for an overview. Plugins that touch file paths must go through the Eel API (https://www.jetbrains.com/help/inspectopedia/UseOptimizedEelFunctions.html) instead of VirtualFile.getCanonicalPath().*

When IntelliJ runs on the host and the project is opened via Gateway's ijent-based Dev Container mode, the file the user wants to reformat lives inside the container; the host references it through an Eel virtual filesystem. VirtualFile.getCanonicalPath() then returns a host-side virtual string like //$devcontainer.ij/<hash>@/workspaces/... which the previous code passed verbatim to the in-container mvn / gradlew process. That process cannot dereference the Eel scheme, so it sees a path that does not exist and silently no-ops, even though the user gets a "Spotless applied" notification and the IDE believes the file was formatted.

Introduce resolveSpotlessIdeHookPath() and route both the Maven -DspotlessIdeHook and the Gradle -PspotlessIdeHook arguments through it. For local projects (EelPathUtils.isPathLocal) we keep the previous VirtualFile.getCanonicalPath() output verbatim — including the leading-slash workaround in the Maven path added in 99a1a12 — so the behavior on local-filesystem projects is unchanged. For Eel-backed paths we translate via EelNioBridgeServiceKt.asEelPath(...) to the container-internal absolute path (e.g. /workspaces/<module>/.../File.java) which mvn / gradlew running inside the container can resolve.