### PR TITLE
Warm up SpotlessOnSaveOptions off-EDT to avoid ijent crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+## 1.2.4
+
+- Support Dev Containers in `ijent` mode which is JetBrain's new
+  architecture for Dev Containers and became the default
+  with IntelliJ IDEA 2026.1.
+  - [#56](https://github.com/lipiridi/spotless-applier/pull/56)
+    Warm up SpotlessOnSaveOptions off-EDT to avoid ijent crash
+
 ## [1.2.3] - 2026-04-10
 
 - [#49](https://github.com/lipiridi/spotless-applier/issues/49) Maven - Fix path containing space in Linux

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginName=Spotless Applier
 pluginRepositoryUrl=https://github.com/lipiridi/spotless-applier
 
 # SemVer format -> https://semver.org
-pluginVersion=1.2.3
+pluginVersion=1.2.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=253

--- a/src/main/kotlin/com/github/lipiridi/spotless/applier/startup/SpotlessApplierStartupActivity.kt
+++ b/src/main/kotlin/com/github/lipiridi/spotless/applier/startup/SpotlessApplierStartupActivity.kt
@@ -1,0 +1,22 @@
+package com.github.lipiridi.spotless.applier.startup
+
+import com.github.lipiridi.spotless.applier.onSave.SpotlessOnSaveOptions
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+/**
+ * Forces the [SpotlessOnSaveOptions] project light service to load off the EDT during project
+ * startup. Without this, the first `getInstance(project)` call happens on the EDT inside
+ * `ActionsOnSaveFileDocumentManagerListener.beforeAllDocumentsSaving` (i.e. on every save), which
+ * triggers the persisted-state load. In a Maven project IntelliJ then expands path macros via
+ * `MavenProjectPathMacroContributor`, which calls `EelProvider.toEelApiBlocking` — forbidden on the
+ * EDT and fatal in ijent-based Dev Container mode.
+ */
+internal class SpotlessApplierStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        readAction {
+            SpotlessOnSaveOptions.getInstance(project)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -54,6 +54,8 @@
         <actionOnSave id="SpotlessActionOnSave"
                       implementation="com.github.lipiridi.spotless.applier.actions.ReformatActionOnSave"
                       order="after FormatOnSaveAction"/>
+        <postStartupActivity
+                implementation="com.github.lipiridi.spotless.applier.startup.SpotlessApplierStartupActivity"/>
     </extensions>
 
     <extensionPoints>


### PR DESCRIPTION
***Context:** Using Spotless-Applier plugin within an IntelliJ Dev-Container in "ijent" mode which is JetBrains' new architecture for Dev Containers, where the full IntelliJ runs on the host and only a thin daemon runs inside the container. It became the default workflow with IntelliJ IDEA 2026.1 (https://blog.jetbrains.com/idea/2026/03/intellij-idea-2026-1/); see Open a project with Dev Container natively (https://www.jetbrains.com/help/idea/open-project-with-dev-container-natively.html) for an overview. Plugins that touch file paths must go through the Eel API (https://www.jetbrains.com/help/inspectopedia/UseOptimizedEelFunctions.html) instead of VirtualFile.getCanonicalPath().*

The on-save listener calls SpotlessOnSaveOptions.getInstance(project) from the EDT. Because the project light service is created lazily on its first access, that EDT call also drives the initial load of the persisted state file. IntelliJ's storage layer then expands path macros, which on Maven projects pulls in
MavenProjectPathMacroContributor; the contributor calls EelProvider.toEelApiBlocking. In Gateway 2025.x ijent-based Dev Container mode that blocking Eel call is forbidden on the EDT and throws IllegalStateException, so the first save crashes with a fatal exception and no file is formatted.

Add a postStartupActivity that pre-instantiates the service inside a readAction during project startup (off-EDT). Once the service exists and its state is loaded, all subsequent EDT calls hit the cached instance with no storage I/O and no macro expansion, so the save listener no longer touches Eel.