### PR TITLE
Use public instead of internal EelPathUtils.isPathLocal

### DIFF
--- a/src/main/java/com/github/lipiridi/spotless/applier/ReformatProcessor.java
+++ b/src/main/java/com/github/lipiridi/spotless/applier/ReformatProcessor.java
@@ -22,8 +22,10 @@ import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Version;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.eel.EelDescriptor;
 import com.intellij.platform.eel.provider.EelNioBridgeServiceKt;
-import com.intellij.platform.eel.provider.utils.EelPathUtils;
+import com.intellij.platform.eel.provider.EelProviderUtil;
+import com.intellij.platform.eel.provider.LocalEelDescriptor;
 import com.intellij.psi.PsiFile;
 import java.io.File;
 import java.nio.file.Path;
@@ -254,7 +256,8 @@ public class ReformatProcessor {
     private String resolveSpotlessIdeHookPath() {
         VirtualFile virtualFile = psiFile.getVirtualFile();
         Path nioPath = virtualFile.toNioPath();
-        if (EelPathUtils.isPathLocal(nioPath)) {
+        EelDescriptor descriptor = EelProviderUtil.getEelDescriptor(nioPath);
+        if (LocalEelDescriptor.INSTANCE.equals(descriptor)) {
             String canonical = virtualFile.getCanonicalPath();
             return canonical != null ? canonical : nioPath.toString();
         }


### PR DESCRIPTION
## API stability of the symbols this PR introduces

  The IntelliJ team flagged the previous version's `EelPathUtils.isPathLocal(Path)` as internal API. The replacement uses public-facing alternatives, but they are still `@ApiStatus.Experimental` in the version this PR targets — the `@SuppressWarnings("UnstableApiUsage")`
  therefore stays. The table below tracks the annotation status across recent IDE versions.

  | Symbol | 2025.3 (target) | 2026.1 (latest stable) | Fully stable? |
  | --- | --- | --- | --- |
  | `EelPathUtils.isPathLocal(Path)` (previously used) | `@Internal` (class-level) | `@Obsolete` (method-level) | no |
  | `EelProviderUtil.getEelDescriptor(Path)` | `@Experimental` | `@Experimental` | no |
  | `LocalEelDescriptor` class | `@Experimental` | `@Experimental` | no |
  | `LocalEelDescriptor.INSTANCE` | `@Experimental` (inherited) | `@Experimental` (inherited) | no |
  | `EelDescriptor` as type | `@Experimental` | `@Experimental` (interface methods) | no |
  | `EelNioBridgeServiceKt.asEelPath(Path)` | `@Internal` (class-level) | `@Experimental` (method-level) | no |

  Notes:

  - Third-party plugins are allowed to depend on `@ApiStatus.Experimental` (compiler warning only), but not on `@ApiStatus.Internal`. The swap moves the previously-internal `isPathLocal` call onto the experimental tier, which is the highest stability currently available.
  - In 2026.1 the JetBrains team downgraded `isPathLocal` itself from `@Internal` to `@Obsolete` — an implicit acknowledgement that third-party plugins relied on it and that the public replacement used here is the intended migration target.
  - `EelNioBridgeServiceKt.asEelPath(Path)` (still called in the non-local branch of `resolveSpotlessIdeHookPath`) is `@Internal` in 2025.3 but already `@Experimental` in 2026.1. No public replacement exists in 2025.3, so it is left in place; it can be revisited once the
  plugin's `sinceBuild` advances past 261.
